### PR TITLE
harden `get_first_resource()` to handle poorly formed input 

### DIFF
--- a/medmorph_pha/models/process_message.py
+++ b/medmorph_pha/models/process_message.py
@@ -86,8 +86,11 @@ message_header_stub = {
 
 def get_first_resource(resource_type, bundle):
     """Iterate through the given bundle, returning the first matching resource of given type"""
-    for entry in bundle["entry"]:
-        if entry["resource"]["resourceType"] == resource_type:
+    if not bundle:
+        return
+
+    for entry in bundle.get("entry", []):
+        if entry.get("resource", {}).get("resourceType") == resource_type:
             return entry["resource"]
 
 

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -1,7 +1,33 @@
 from flask import url_for
 
 from conftest import MockedResponse
-from medmorph_pha.models.process_message import process_message_operation
+from medmorph_pha.models.process_message import (
+    get_first_resource,
+    process_message_operation,
+)
+
+
+def test_get_first_legit(reporting_bundle_example):
+    result = get_first_resource('Bundle', reporting_bundle_example)
+    assert result['resourceType'] == 'Bundle'
+    assert result['id'] == 'content-bundle-example'
+
+
+def test_get_first_none():
+    result = get_first_resource('Bundle', None)
+    assert result is None
+
+
+def test_get_first_bogus():
+    bogus_bundle = {}
+    result = get_first_resource('Patient', bogus_bundle)
+    assert result is None
+
+
+def test_get_first_bogus_nest():
+    bogus_bundle = {'entry': [{'resourceType': 'Patient'}]}
+    result = get_first_resource('Patient', bogus_bundle)
+    assert result is None
 
 
 def test_process_message(


### PR DESCRIPTION
returns None if not found.